### PR TITLE
⬆️ Update required tilt and helm

### DIFF
--- a/integrate/README.md
+++ b/integrate/README.md
@@ -38,7 +38,7 @@ For local development
 
 - Install [Tilt](https://tilt.dev/)
   - On macOS via Homebrew: `brew install tilt-dev/tap/tilt`
-  - On Linux or WSL2 for Windows: `curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v0.22.9/tilt.0.22.9.linux.x86_64.tar.gz | tar -xzv tilt && sudo mv tilt /usr/local/bin/tilt
+  - On Linux or WSL2 for Windows: `curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v0.27.2/tilt.0.27.2.linux.x86_64.tar.gz | tar -xzv tilt && sudo mv tilt /usr/local/bin/tilt
   - Others see https://docs.tilt.dev/install.html
 
 ## Start

--- a/integrate/README.md
+++ b/integrate/README.md
@@ -33,7 +33,7 @@ For local development
 - Install [helm](https://helm.sh/)
 
   - On macOS via Homebrew: `brew install helm`
-  - On Linux or WSL2 for Windows: `curl -LO https://get.helm.sh/helm-v3.7.0-linux-amd64.tar.gz && tar -zxvf helm-v3.0.0-linux-amd64.tar.gz && chmod +x linux-amd64/helm && sudo mv linux-amd64/helm /usr/local/bin/helm`
+  - On Linux or WSL2 for Windows: `curl -LO https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz && tar -zxvf helm-v3.8.2-linux-amd64.tar.gz && chmod +x linux-amd64/helm && sudo mv linux-amd64/helm /usr/local/bin/helm`
   - Others see https://helm.sh/docs/intro/install/
 
 - Install [Tilt](https://tilt.dev/)

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -32,7 +32,7 @@ A quick (less than 10 minutes) and easy process to protect data with TDF using t
 
 - Install [Tilt](https://tilt.dev/)
   - On macOS via Homebrew: `brew install tilt-dev/tap/tilt`
-  - On Linux or WSL2 for Windows: `curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v0.22.9/tilt.0.22.9.linux.x86_64.tar.gz | tar -xzv tilt && sudo mv tilt /usr/local/bin/tilt
+  - On Linux or WSL2 for Windows: `curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v0.27.2/tilt.0.27.2.linux.x86_64.tar.gz | tar -xzv tilt && sudo mv tilt /usr/local/bin/tilt
   - Others see https://docs.tilt.dev/install.html
 
 ### Pull repository

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -32,7 +32,7 @@ A quick (less than 10 minutes) and easy process to protect data with TDF using t
 
 - Install [Tilt](https://tilt.dev/)
   - On macOS via Homebrew: `brew install tilt-dev/tap/tilt`
-  - On Linux or WSL2 for Windows: `curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v0.27.2/tilt.0.27.2.linux.x86_64.tar.gz | tar -xzv tilt && sudo mv tilt /usr/local/bin/tilt
+  - On Linux or WSL2 for Windows: `curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v0.27.2/tilt.0.27.2.linux.x86_64.tar.gz | tar -xzv tilt && sudo mv tilt /usr/local/bin/tilt`
   - Others see https://docs.tilt.dev/install.html
 
 ### Pull repository

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -27,7 +27,7 @@ A quick (less than 10 minutes) and easy process to protect data with TDF using t
 - Install [helm](https://helm.sh/)
 
   - On macOS via Homebrew: `brew install helm`
-  - On Linux or WSL2 for Windows: `curl -LO https://get.helm.sh/helm-v3.7.0-linux-amd64.tar.gz && tar -zxvf helm-v3.0.0-linux-amd64.tar.gz && chmod +x linux-amd64/helm && sudo mv linux-amd64/helm /usr/local/bin/helm`
+  - On Linux or WSL2 for Windows: `curl -LO https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz && tar -zxvf helm-v3.8.2-linux-amd64.tar.gz && chmod +x linux-amd64/helm && sudo mv linux-amd64/helm /usr/local/bin/helm`
   - Others see https://helm.sh/docs/intro/install/
 
 - Install [Tilt](https://tilt.dev/)

--- a/quickstart/Tiltfile
+++ b/quickstart/Tiltfile
@@ -1,4 +1,8 @@
 load("ext://helm_resource", "helm_resource", "helm_repo")
+load("ext://min_tilt_version", "min_tilt_version")
+
+# The helm_resource extension uses the 'new extensions api' introduced in tilt 0.25
+min_tilt_version("0.25")
 
 k8s_yaml(
     helm(


### PR DESCRIPTION
- We need at least 0.25 for the `helm_resource` extension
- Updates the readmes to recommend the latest release, 0.27.2, just to let us stay ahead of the game
- Updates required helm version to 3.8+, since we are using OCI container registries for helm install