### PR TITLE
Don't override images in quickstart

### DIFF
--- a/quickstart/Tiltfile
+++ b/quickstart/Tiltfile
@@ -53,7 +53,7 @@ helm_resource(
 helm_resource(
     "attributes",
     "oci://ghcr.io/opentdf/charts/attributes",
-    flags=["--version", "0.0.1", "-f", "helm/values-attributes.yaml"],
+    flags=["--version", "sha-93e1fa6", "-f", "helm/values-attributes.yaml"],
     labels="backend",
     resource_deps=["postgresql"],
 )
@@ -61,7 +61,7 @@ helm_resource(
 helm_resource(
     "claims",
     "oci://ghcr.io/opentdf/charts/claims",
-    flags=["--version", "0.0.1", "-f", "helm/values-claims.yaml"],
+    flags=["--version", "sha-93e1fa6", "-f", "helm/values-claims.yaml"],
     labels="backend",
     resource_deps=["postgresql"],
 )
@@ -69,7 +69,7 @@ helm_resource(
 helm_resource(
     "entitlements",
     "oci://ghcr.io/opentdf/charts/entitlements",
-    flags=["--version", "0.0.1", "-f", "helm/values-entitlements.yaml"],
+    flags=["--version", "sha-93e1fa6", "-f", "helm/values-entitlements.yaml"],
     labels="backend",
     resource_deps=["postgresql"],
 )
@@ -85,7 +85,7 @@ helm_resource(
 helm_resource(
     "kas",
     "oci://ghcr.io/opentdf/charts/kas",
-    flags=["--version", "0.0.1", "-f", "helm/values-kas.yaml"],
+    flags=["--version", "sha-93e1fa6", "-f", "helm/values-kas.yaml"],
     labels="backend",
     resource_deps=["attributes", "keycloak"],
 )
@@ -93,7 +93,7 @@ helm_resource(
 helm_resource(
     "keycloak-bootstrap",
     "oci://ghcr.io/opentdf/charts/keycloak-bootstrap",
-    flags=["--version", "0.4.2", "-f", "helm/values-bootstrap.yaml"],
+    flags=["--version", "sha-93e1fa6", "-f", "helm/values-bootstrap.yaml"],
     labels="utility",
     resource_deps=["attributes", "entitlements", "keycloak"],
 )

--- a/quickstart/Tiltfile
+++ b/quickstart/Tiltfile
@@ -53,7 +53,7 @@ helm_resource(
 helm_resource(
     "attributes",
     "oci://ghcr.io/opentdf/charts/attributes",
-    flags=["--version", "sha-93e1fa6", "-f", "helm/values-attributes.yaml"],
+    flags=["--version", "0.0.0-sha-0b804dd", "-f", "helm/values-attributes.yaml"],
     labels="backend",
     resource_deps=["postgresql"],
 )
@@ -61,7 +61,7 @@ helm_resource(
 helm_resource(
     "claims",
     "oci://ghcr.io/opentdf/charts/claims",
-    flags=["--version", "sha-93e1fa6", "-f", "helm/values-claims.yaml"],
+    flags=["--version", "0.0.0-sha-0b804dd", "-f", "helm/values-claims.yaml"],
     labels="backend",
     resource_deps=["postgresql"],
 )
@@ -69,7 +69,7 @@ helm_resource(
 helm_resource(
     "entitlements",
     "oci://ghcr.io/opentdf/charts/entitlements",
-    flags=["--version", "sha-93e1fa6", "-f", "helm/values-entitlements.yaml"],
+    flags=["--version", "0.0.0-sha-0b804dd", "-f", "helm/values-entitlements.yaml"],
     labels="backend",
     resource_deps=["postgresql"],
 )
@@ -85,7 +85,7 @@ helm_resource(
 helm_resource(
     "kas",
     "oci://ghcr.io/opentdf/charts/kas",
-    flags=["--version", "sha-93e1fa6", "-f", "helm/values-kas.yaml"],
+    flags=["--version", "0.0.0-sha-0b804dd", "-f", "helm/values-kas.yaml"],
     labels="backend",
     resource_deps=["attributes", "keycloak"],
 )
@@ -93,7 +93,7 @@ helm_resource(
 helm_resource(
     "keycloak-bootstrap",
     "oci://ghcr.io/opentdf/charts/keycloak-bootstrap",
-    flags=["--version", "sha-93e1fa6", "-f", "helm/values-bootstrap.yaml"],
+    flags=["--version", "0.0.0-sha-0b804dd", "-f", "helm/values-bootstrap.yaml"],
     labels="utility",
     resource_deps=["attributes", "entitlements", "keycloak"],
 )

--- a/quickstart/helm/values-attributes.yaml
+++ b/quickstart/helm/values-attributes.yaml
@@ -1,8 +1,6 @@
 logLevel: DEBUG
 serverRootPath: /attributes
 serverPublicName: "Attribute Authority"
-image:
-  image: ghcr.io/opentdf/attributes:main
 oidc:
   clientId: tdf-attributes
   externalHost: http://localhost:65432/auth

--- a/quickstart/helm/values-bootstrap.yaml
+++ b/quickstart/helm/values-bootstrap.yaml
@@ -36,8 +36,6 @@ entitlements:
     user1:
       - https://example.com/attr/Classification/value/S
       - https://example.com/attr/COI/value/PRX
-image:
-  image: ghcr.io/opentdf/keycloak-bootstrap:main
 keycloak:
   hostname: http://keycloak-http
   clientId: tdf-client

--- a/quickstart/helm/values-claims.yaml
+++ b/quickstart/helm/values-claims.yaml
@@ -1,5 +1,3 @@
-image:
-  image: ghcr.io/opentdf/claims:main
 secretRef:
  name: claims-secrets
 service:

--- a/quickstart/helm/values-entitlements.yaml
+++ b/quickstart/helm/values-entitlements.yaml
@@ -1,8 +1,6 @@
 rootPath: /entitlements
 publicName: "Entitlement"
 logLevel: DEBUG
-image:
-  image: ghcr.io/opentdf/entitlements:main
 postgres:
   host: postgresql
   port: 5432

--- a/quickstart/helm/values-kas.yaml
+++ b/quickstart/helm/values-kas.yaml
@@ -1,8 +1,6 @@
 endpoints:
   easHost: http://attributes:4020
   oidcPubkeyEndpoint: http://keycloak-http
-image:
-  image: ghcr.io/opentdf/kas:main
 ingress:
   enabled: true
   annotations:

--- a/quickstart/helm/values-keycloak.yaml
+++ b/quickstart/helm/values-keycloak.yaml
@@ -1,3 +1,6 @@
+image:
+  repository: ghcr.io/opentdf/keycloak
+  tag: 0.0.0-sha-0b804dd
 postgresql:
   enabled: false
   postgresqlUsername: postgres

--- a/quickstart/helm/values-keycloak.yaml
+++ b/quickstart/helm/values-keycloak.yaml
@@ -1,6 +1,3 @@
-image:
-  repository: ghcr.io/opentdf/keycloak
-  tag: main
 postgresql:
   enabled: false
   postgresqlUsername: postgres

--- a/quickstart/helm/values-keycloak.yaml
+++ b/quickstart/helm/values-keycloak.yaml
@@ -1,6 +1,7 @@
 image:
   repository: ghcr.io/opentdf/keycloak
-  tag: 0.0.0-sha-0b804dd
+  # Keycloak is a non-OpenTDF chart, but with an OpenTDF image
+  tag: sha-0b804dd
 postgresql:
   enabled: false
   postgresqlUsername: postgres


### PR DESCRIPTION
If we need to lock versions, we should lock chart versions, not image versions.

Locking image versions and not chart versions will just create problems when one and not the other is updated.

Also, image tag overrides changed from `image.image` to `image.repo|image.tag`

_For now_ also locking Quickstart to specific Helm chart tags from specific `main` build (https://github.com/opentdf/backend/actions/runs/2241702911) - we can revisit this later if we want to go back to QS automatically absorbing the current `main` artifact.